### PR TITLE
Skip forward in time if diff becomes larger than interval

### DIFF
--- a/tock.js
+++ b/tock.js
@@ -132,7 +132,8 @@ Tock.prototype._tick = function () {
     if (Math.round(this.elapsed) === this.elapsed) { this.elapsed += '.0'; }
 
     var t = this,
-        diff = (Date.now() - this.start_time) - this.time;
+        diff = (Date.now() - this.start_time) - this.time,
+        next_interval_in = this.interval - diff;
 
     if (this.callback !== undefined) {
         this.callback(this);
@@ -144,8 +145,16 @@ Tock.prototype._tick = function () {
         this.complete();
     }
 
-    if (this.go) {
-        this.timeout = window.setTimeout(function () { t._tick(); }, (this.interval - diff));
+    if (next_interval_in <= 0) {
+        missed_ticks = Math.floor(Math.abs(next_interval_in) / this.interval)
+        this.time += missed_ticks * this.interval
+        if (this.go) {
+            this._tick();
+        }
+    } else {
+        if (this.go) {
+            this.timeout = window.setTimeout(function () { t._tick(); }, next_interval_in);
+        }
     }
 };
 


### PR DESCRIPTION
I saw you mentioned it the updated README that this could be an issue, and indeed I already ran into it and fixed it with this code.

In a long running countdown timer that was doing some intensive work (redrawing a canvas element) in its callback it actually caused some confusing display problems. It eventually would run all the missing ticks, but the timer counted down very quickly rather than just rendering the latest real value. 

This will just immediately run the tick function when `this.interval - diff` is less than or equal to zeor, and it will adjust `this.time` appropriately for the ticks it missed.
