### PR TITLE
Fix stop/reset bug when there are multiple instances of a timer on the same page.

### DIFF
--- a/tock.js
+++ b/tock.js
@@ -4,12 +4,19 @@
 *    sitepoint.com/creating-accurate-timers-in-javascript/
 */
 var Tock = (function(options) {
+
+  Tock.instances = (Tock.instances || 0) + 1;
+
   var go = false,
       interval = options.interval || 10,
       countdown = options.countdown || false,
       final_time = 0,
+      start_time = 0,
+      time = 0,
+      elapsed = 0,
       callback = options.callback,
-      complete = options.complete;
+      complete = options.complete,
+      prefix = "Tock" + Tock.instances;
 
   /**
    * Reset the clock
@@ -68,6 +75,7 @@ var Tock = (function(options) {
     } else {
       if (go) {
         timeout = window.setTimeout(_tick, next_interval_in);
+        timeout = prefix + timeout;
       }
     }
   }
@@ -78,7 +86,7 @@ var Tock = (function(options) {
   function stop() {
     go = false;
     final_time = (Date.now() - start_time);
-    window.clearTimeout(timeout);
+    window.clearTimeout(timeout.replace(prefix));
   }
   
   /**


### PR DESCRIPTION
I ran into a problem where if you call reset() or stop() with multiple timers running it will actually stop all of them. :)

This is because the setTimeout ID returns just an incremented number. After the first timeout was stopped it would then stop the second occurrence of the timer. To solve this issue I added a prefix which adds a unique id to each timer instance.

I was also having issues with clicking "reset" borking the time of the other timers. Adding start_time, time, and elapsed as private variables seemed to fix this issue. I don't think it broke anything. ;)
