### PR TITLE
Removed global var end_time that's never used

### DIFF
--- a/tock.js
+++ b/tock.js
@@ -216,7 +216,6 @@ Date.now = Date.now || function() { return +new Date(); };
     function _startCountdown(duration) {
       duration_ms = duration;
       start_time = Date.now();
-      end_time = start_time + duration_ms;
       time = 0;
       elapsed = '0.0';
       go = true;


### PR DESCRIPTION
Removed an implicit set of a global variable `end_time` that is never used and prevent contamination of global namespace.