### PR TITLE
remove ref to window for use in node

### DIFF
--- a/tock.js
+++ b/tock.js
@@ -40,7 +40,7 @@ if ( typeof Function.prototype.bind != 'function' ) {
       this.final_time = 0;
       this.go = false;
       this.callback(this);
-      window.clearTimeout(this.timeout);
+      clearTimeout(this.timeout);
       this.complete(this);
       return;
     }
@@ -60,7 +60,7 @@ if ( typeof Function.prototype.bind != 'function' ) {
       }
     }
     else if ( this.go ) {
-      this.timeout = window.setTimeout(_tick.bind(this), next_interval_in);
+      this.timeout = setTimeout(_tick.bind(this), next_interval_in);
     }
   }
 
@@ -161,7 +161,7 @@ if ( typeof Function.prototype.bind != 'function' ) {
     this.pause_time = this.lap();
     this.go = false;
 
-    window.clearTimeout(this.timeout);
+    clearTimeout(this.timeout);
 
     if ( this.countdown ) {
       this.final_time = this.duration_ms - this.time;


### PR DESCRIPTION
tock currently throws a ReferenceError when used in Node. Removing the reference to `window` will fix this error without breaking browser functionality.

another option would be to add a line like `window = window || global;` around line [31](https://github.com/mrchimp/tock/pull/32/files#diff-916f7a4d33b702d5c6f46b3efe102c4dL31) instead.